### PR TITLE
Big refactor and add multiprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.aux
 *.csv
 *.txt
+__pycache__/
+.vscode/

--- a/author.py
+++ b/author.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass, field
+from enums import CollateBy, Column
+
+
+@dataclass
+class Author:
+    name: str
+    email: str
+    first_date: str
+    last_date: str = field(init=False)
+    commits: int = 0
+    added: int = 0
+    deleted: int = 0
+
+    def __post_init__(self):
+        self.last_date = self.first_date
+
+    def edits(self):
+        return self.added + self.deleted
+
+    def report(self, keys: list[Column], totlines: int):
+        row: list[str | int] = [""] * len(keys)
+        for i, key in enumerate(keys):
+            if key == Column.NAME:
+                row[i] = self.name
+            elif key == Column.EMAIL:
+                row[i] = self.email
+            elif key == Column.NAME_EMAIL:
+                row[i] = f"{self.name} <{self.email}>"
+            elif key == Column.COMMITS:
+                row[i] = self.commits
+            elif key == Column.ADDED:
+                row[i] = self.added
+            elif key == Column.DELETED:
+                row[i] = self.deleted
+            elif key == Column.EDITS:
+                row[i] = self.edits()
+            elif key == Column.PERCENT:
+                row[i] = "%.1f" % ((100.0 * self.edits()) / totlines)
+            elif key == Column.FIRST_DATE:
+                row[i] = self.first_date
+            elif key == Column.LAST_DATE:
+                row[i] = self.last_date
+        return row
+
+    def __str__(self):
+        return "%s <%s>" % (self.name, self.email)
+
+
+@dataclass
+class Authors:
+    by: CollateBy
+    authors: dict[str | tuple[str, str], Author] = field(default_factory=dict, init=False)
+
+    def add_get_author(self, name: str, email: str, date: str) -> Author:
+        key = (name, email)
+        if self.by == CollateBy.EMAIL:
+            key = email
+        elif self.by == CollateBy.NAME:
+            key = name
+
+        if key not in self.authors:
+            self.authors[key] = Author(name, email, date)
+
+        return self.authors[key]
+
+    def values(self):
+        return self.authors.values()

--- a/countlines.py
+++ b/countlines.py
@@ -1,269 +1,243 @@
 #!/usr/bin/env python3
 # Copyright (c) 2018-2025, Jesper Öqvist
 import argparse
-import sys, os, subprocess
+import multiprocessing as mp
+import os
 import re
-
+import subprocess
+import sys
 from datetime import datetime
+from typing import Optional
+
+from author import Author, Authors
+from enums import CollateBy, Column, OutputFormat
+from output_formats import output_csv, output_plaintext, output_tex
 
 strptime = datetime.strptime
 
-class Author:
-    def __init__(self, name, email, first_date):
-        self.name = name
-        self.email = email
-        self.first_date = first_date
-        self.last_date = first_date
-        self.commits = 0
-        self.added = 0
-        self.deleted = 0
 
-    def edits(s):
-        return s.added + s.deleted
+class NumStatGetter:
+    def __init__(self, commit_hashes: list[str]):
+        self.commit_hashes = commit_hashes
+        self.completed = 0
 
-    def report(s, keys, totlines):
-        row = [""] * len(keys)
-        for i,key in enumerate(keys):
-            if key == 'name':
-                row[i] = s.name
-            elif key == 'email':
-                row[i] = s.email
-            elif key == 'name_email':
-                row[i] = f'{s.name} <{s.email}>'
-            elif key == 'commits':
-                row[i] = s.commits
-            elif key == 'added':
-                row[i] = s.added
-            elif key == 'deleted':
-                row[i] = s.deleted
-            elif key == 'edits':
-                row[i] = s.edits()
-            elif key == 'percent':
-                row[i] = "%.1f" % ((100.0 * s.edits())/totlines)
-            elif key == 'first_date':
-                row[i] = s.first_date
-            elif key == 'last_date':
-                row[i] = s.last_date
-        return row
+    def get_numstats_for_hash(self, commit: str, queue: Optional[mp.Queue] = None) -> list[str]:
+        out, _ = subprocess.Popen(
+            ["git", "show", commit, "--numstat", "--format=%an#%ae#%ad", "--date=short"], stdout=subprocess.PIPE
+        ).communicate()
+        out = out.decode(encoding="UTF-8")
 
-    def __str__(s):
-        return '%s <%s>' % (s.name, s.email)
+        if queue is not None:
+            # We send a dummy message to the queue to indicate that this commit has been processed.
+            queue.put("done")
+        return out.splitlines()
 
-def index(authors, name, email, date, by):
-    if by == 'name':
-        key = name
-    elif by == 'email':
-        key = email
-    else:
-        key = (name, email)
-    if  key not in authors:
-        authors[key] = Author(name, email, date)
-    return authors[key]
+    @staticmethod
+    def progress_listener(queue: mp.Queue, number_of_commits: int):
+        sys.stderr.write("Counting lines in commits:\n")
+        for i in range(number_of_commits):
+            sys.stderr.write("\rcommit: %d / %d%s" % (i, number_of_commits, " " * 15))
+            queue.get()
+        sys.stderr.write("\r%s\r" % (" " * 25))
 
-def gather_data(args, repo, alias):
+    def get_numstats_multiprocessing(self) -> list[list[str]]:
+        cpu_count = os.cpu_count()
+        if cpu_count is None:
+            # Apparently os.cpu_count() can return None. In that case we default to single threaded execution.
+            return self.get_numstats_singlethreaded()
+
+        # When we run things in parallel, the individual processes doesn't know about each other,
+        # and we can't use a simple counter.
+        # Instead, we have each process report when it is done to a queue, and we have a separate
+        # process that listens to the queue and prints the progress.
+        manager = mp.Manager()
+        queue = manager.Queue()
+        progress_bar = mp.Process(
+            target=self.progress_listener,
+            args=(
+                queue,
+                len(self.commit_hashes),
+            ),
+        )
+        progress_bar.start()
+
+        # We use cpu_count - 4 to leave some CPU cores free for the system.
+        with mp.Pool(cpu_count - 4) as pool:
+            numstats = pool.starmap(self.get_numstats_for_hash, [(commit, queue) for commit in self.commit_hashes])
+
+        progress_bar.join()
+        return numstats
+
+    def get_numstats_singlethreaded(self) -> list[list[str]]:
+        numstats = []
+        N = len(self.commit_hashes)
+        for i, commit in enumerate(self.commit_hashes):
+            sys.stderr.write("\rcommit: %d / %d%s" % (i, N, " " * 15))
+            numstats.append(self.get_numstats_for_hash(commit))
+        return numstats
+
+
+def gather_data(args: argparse.Namespace, repo: str, alias: dict[str, str]) -> Authors:
     os.chdir(repo)
 
     # Check if branch exists
-    out, err = subprocess.Popen(['git', 'branch', '--list'], stdout=subprocess.PIPE).communicate()
-    allbranches = [branch.replace("*", "").strip() for branch in out.decode(encoding='UTF-8').splitlines()]
+    out, _ = subprocess.Popen(["git", "branch", "--list"], stdout=subprocess.PIPE).communicate()
+    allbranches = [branch.replace("*", "").strip() for branch in out.decode(encoding="UTF-8").splitlines()]
 
     if args.branch not in allbranches:
-        raise Exception('Branch %s does not exist' % args.branch)
+        raise Exception("Branch %s does not exist" % args.branch)
 
-    authors = {}
+    authors: Authors = Authors(args.by)
 
-    re_auth = re.compile(r'^(.+)#(.*)')
-    re_edits = re.compile(r'^(\d+)\s+(\d+)') # Binary files start with - -.
-    cmd = ['git', 'rev-list']
+    re_edits = re.compile(r"^(\d+)\s+(\d+)")  # Binary files start with - -.
+    cmd = ["git", "rev-list"]
     if args.since:
-        cmd += [f'--since-as-filter={args.since}']
+        cmd += [f"--since-as-filter={args.since}"]
     if args.until:
-        cmd += [f'--until={args.until}']
+        cmd += [f"--until={args.until}"]
     if args.max_count:
-        cmd += [f'--max-count={args.max_count}']
+        cmd += [f"--max-count={args.max_count}"]
     cmd += [args.branch]
-    revs = subprocess.check_output(cmd).split()
-    N = len(revs)
-    n = 0
-    for rev in revs:
-        n += 1
-        sys.stderr.write('\rcommit: %d / %d%s' % (n, N, ' '*15))
-        out, err = subprocess.Popen(['git', 'show', rev, '--numstat', '--format=%an#%ae#%ad', '--date=short'], stdout=subprocess.PIPE).communicate()
-        out = out.decode(encoding='UTF-8')
-        lines = out.splitlines()
-        auth_line = lines[0].split("#")
-        auth_line = auth_line[0] + "#" + auth_line[1]
-        date = lines[0].split("#")[-1]
+    commit_hashes_reverse = subprocess.check_output(cmd).decode().split()
 
-        auth = re_auth.match(auth_line)
-        if not auth:
-            raise Exception('Malformed author line? [%s]' % auth_line)
+    helper = NumStatGetter(commit_hashes_reverse)
+    if args.multiprocessing:
+        liness = helper.get_numstats_multiprocessing()
+    else:
+        liness = helper.get_numstats_singlethreaded()
 
-        name,email = auth.group(1), auth.group(2)
-        auth = index(authors, alias.get(email, name), email, date, args.by)
+    for lines in liness:
+        # for rev in revs:
+        name, email, date = lines[0].split("#")
 
-        if strptime(date, '%Y-%m-%d') < strptime(auth.first_date, '%Y-%m-%d'):
-            auth.first_date = date
-        if strptime(date, '%Y-%m-%d') > strptime(auth.last_date, '%Y-%m-%d'):
-            auth.last_date = date
+        author = authors.add_get_author(alias.get(email, name), email, date)
 
-        auth.commits += 1
+        if strptime(date, "%Y-%m-%d") < strptime(author.first_date, "%Y-%m-%d"):
+            author.first_date = date
+        if strptime(date, "%Y-%m-%d") > strptime(author.last_date, "%Y-%m-%d"):
+            author.last_date = date
+
+        author.commits += 1
         for ln in lines[1:]:
             edits = re_edits.match(ln)
             if edits:
-                auth.added += int(edits.group(1))
-                auth.deleted += int(edits.group(2))
-    sys.stderr.write('\r%s\r' % (' ' * 25))
+                author.added += int(edits.group(1))
+                author.deleted += int(edits.group(2))
+    sys.stderr.write("\r%s\r" % (" " * 25))
     return authors
 
-COLNAMES={
-'name': 'Author',
-'email': 'Author',
-'name_email': 'Author',
-'commits': 'Commits',
-'added': 'Inserted',
-'deleted': 'Removed',
-'edits': 'Total',
-'percent': 'Percent',
-'first_date': 'First commit',
-'last_date': 'Last commit',
-}
 
-COLNAMES_TEX={
-'name': '\\emph{Author}',
-'email': '\\emph{Author',
-'name_email': '\\emph{Author}',
-'commits': '\\emph{Commits}',
-'added': '\\emph{Inserted}',
-'deleted': '\\emph{Removed}',
-'edits': '$\\Sigma\\,\\downarrow$',
-'percent': '\\%',
-'first_date': '\\emph{First commit}',
-'last_date': '\\emph{Last commit}',
-}
-
-def output_data(args, authors):
+def output_data(args: argparse.Namespace, authors: Authors):
     totlines = sum(map(lambda x: x.edits(), authors.values()))
-    sortkey = lambda a: a.edits() if args.sort == 'edits' else a.commits
-    authors = sorted(authors.values(), key=sortkey, reverse=True)
+
+    def sortkey(author: Author):
+        if args.sort == "edits":
+            return author.edits()
+        else:
+            return author.commits
+
+    authors_list = sorted(authors.values(), key=sortkey, reverse=True)
     keys = list(args.columns)
-    for i,k in enumerate(keys):
-        if k == 'author':
-            if args.by == 'both':
-                keys[i] = 'name_email'
+    for i, k in enumerate(keys):
+        if k == Column.AUTHOR:
+            if args.by == CollateBy.BOTH:
+                keys[i] = Column.NAME_EMAIL
             else:
                 keys[i] = args.by
 
-    if args.limit != None:
-        authors = authors[:int(args.limit)]
-    if args.output == 'plaintext':
-        rows = [[COLNAMES[c] for c in keys]]
-        lens = [ len(r) for r in rows[0] ]
-        for auth in authors:
-            row = auth.report(keys, totlines)
-            for i in range(len(lens)):
-                lens[i] = max(lens[i], len(str(row[i])))
-            rows += [ row ]
-        offs = 0
-        for row in rows:
-            items = []
-            for i in range(len(lens)-1):
-                items += [ f'{row[i]:<{lens[i]+2}}' ]
-            items += [ str(row[-1]) ]
-            print(''.join(items))
-    elif args.output.startswith('tex'):
-        if args.output == 'tex':
-            print('''\\documentclass[10pt,border=10pt]{standalone}
-\\usepackage{booktabs}
-\\usepackage{newtxtext}
-\\begin{document}''')
-        print('\\begin{tabular}{lrrrrr}')
-        print('\\toprule')
-        print(' & '.join([COLNAMES_TEX[c] for c in keys]) + '\\\\')
-        print('\\midrule')
-        for auth in authors:
-            print((' & '.join([str(x) for x in auth.report(keys, totlines)]) + ' \\\\'))
-        print('\\bottomrule')
-        print('\\end{tabular}')
-        if args.output == 'tex':
-            print('\\end{document}')
-    elif args.output == 'csv':
-        print(','.join(keys))
-        for auth in authors:
-            print(','.join([str(x) for x in auth.report(keys, totlines)]))
-    elif args.output == 'alias':
-        for auth in authors:
-            print('%s = %s' % (auth.email, auth.name))
+    if args.limit is not None:
+        authors_list = authors_list[: int(args.limit)]
+    if args.output == OutputFormat.PLAINTEXT:
+        output_plaintext(keys, authors_list, totlines)
+    elif args.output.startswith("tex"):
+        output_tex(keys, authors_list, totlines, args.output)
+    elif args.output == OutputFormat.CSV:
+        output_csv(keys, authors_list, totlines)
+    elif args.output == OutputFormat.ALIAS:
+        for author in authors_list:
+            print("%s = %s" % (author.email, author.name))
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Counts lines in git project.')
-    parser.add_argument('repository', help='The git repository to count lines in.')
-    parser.add_argument('--by',
-            choices=['name', 'email', 'both'],
-            default='both',
-            help='Collate by author name, email, or both')
-    parser.add_argument('--output',
-            choices=['plaintext', 'tex', 'tex-table', 'csv', 'alias'],
-            default='plaintext',
-            help='Output as TeX document')
-    parser.add_argument('--limit',
-            help='Maximum number of output rows')
-    parser.add_argument('--alias', help='File mapping emails to author names')
-    parser.add_argument('--sort',
-            choices=['edits', 'commits'],
-            default='edits',
-            help='Column to sort on')
-    parser.add_argument('--since', '--after',
-            help='Limit statistics to commits more recent than this date.',
-            default=None)
-    parser.add_argument('--until', '--before',
-            help='Limit statistics to commits older than this date.',
-            default=None)
-    parser.add_argument('--branch',
-            help='Branch to count commits on. Default is "master"',
-            default='master')
-    parser.add_argument('--max-count', '-n',
-            help='Limit to the MAX_COUNT most recent commits.')
-    cols = sorted(['author'] + list(COLNAMES.keys()))
-    parser.add_argument('--columns',
-            default=None,
-            help=f'Comma-separated list of column to display. Column names are: {', '.join(cols)}')
+    parser = argparse.ArgumentParser(
+        description="Counts lines in git project.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # Show default values in help text.
+    )
+    parser.add_argument("repository", type=str, help="The git repository to count lines in.")
+    parser.add_argument(
+        "--by",
+        type=CollateBy,
+        choices=CollateBy,
+        default=CollateBy.BOTH,
+        help="Collate by author name, email, or both",
+    )
+    parser.add_argument(
+        "--output",
+        choices=OutputFormat,
+        default=OutputFormat.PLAINTEXT,
+        help="Select output format.",
+        type=OutputFormat,
+    )
+    parser.add_argument("--limit", help="Maximum number of output rows", type=int)
+    parser.add_argument("--alias", help="File mapping emails to author names")
+    parser.add_argument("--sort", choices=["edits", "commits"], default="edits", help="Column to sort on")
+    parser.add_argument(
+        "--since", "--after", help="Limit statistics to commits more recent than this date", default=None
+    )
+    parser.add_argument("--until", "--before", help="Limit statistics to commits older than this date", default=None)
+    parser.add_argument("--branch", help="Branch to count commits on", default="master")
+    parser.add_argument("--max-count", "-n", help="Limit to the MAX_COUNT most recent commits")
+    parser.add_argument(
+        "--columns",
+        type=Column,
+        default=None,
+        nargs="*",
+        help="Comma-separated list of column to display.",
+        choices=sorted(Column),
+    )
+    parser.add_argument(
+        "--multiprocessing",
+        action="store_true",
+        help="Use multiprocessing to speed up the counting of lines.",
+    )
 
     args = parser.parse_args()
 
     if args.columns is None:
-        if args.output == 'csv':
-            args.columns = ['author', 'commits', 'added', 'deleted', 'edits', 'percent']
+        if args.output == OutputFormat.CSV:
+            args.columns = [Column.AUTHOR, Column.COMMITS, Column.ADDED, Column.DELETED, Column.EDITS, Column.PERCENT]
         else:
-            args.columns = ['author', 'commits', 'added', 'deleted', 'edits', 'first_date', 'last_date']
-    else:
-        args.columns = args.columns.split(',')
+            args.columns = [
+                Column.AUTHOR,
+                Column.COMMITS,
+                Column.ADDED,
+                Column.DELETED,
+                Column.EDITS,
+                Column.FIRST_DATE,
+                Column.LAST_DATE,
+            ]
 
-    for col in args.columns:
-        if not col in cols:
-            raise Exception(f'ERROR: unknown column name "{col}"')
-
-    repo = args.repository
+    repo: str = args.repository
     if not os.path.isdir(repo):
         # Check out the repo to local directory.
-        sys.stderr.write(f'Cloning {repo} into ./repo\n')
-        if not os.path.isdir('repo'):
-            exit_code = subprocess.call(['git', 'clone', repo, 'repo'])
+        sys.stderr.write(f"Cloning {repo} into ./repo\n")
+        if not os.path.isdir("repo"):
+            exit_code = subprocess.call(["git", "clone", repo, "repo"])
             if exit_code != 0:
-                raise Exception('Failed to fetch git repository %s' % repo)
-        repo = 'repo'
+                raise Exception("Failed to fetch git repository %s" % repo)
+        repo = "repo"
 
     # Read author alias file:
-    alias = {}
+    alias: dict[str, str] = {}
     if args.alias:
-        with open(args.alias, 'r') as fp:
+        with open(args.alias, "r") as fp:
             for ln in fp.readlines():
-                email, name = ln.split('=')
+                email, name = ln.split("=")
                 alias[email.strip()] = name.strip()
 
     data = gather_data(args, repo, alias)
     output_data(args, data)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/enums.py
+++ b/enums.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from enum import StrEnum, auto
+
+
+class Column(StrEnum):
+    AUTHOR = auto()
+    NAME = auto()
+    EMAIL = auto()
+    NAME_EMAIL = auto()
+    COMMITS = auto()
+    ADDED = auto()
+    DELETED = auto()
+    EDITS = auto()
+    PERCENT = auto()
+    FIRST_DATE = auto()
+    LAST_DATE = auto()
+
+    @staticmethod
+    def column_to_string_map() -> dict[Column, str]:
+        return {
+            Column.AUTHOR: "Author",
+            Column.NAME: "Author",
+            Column.EMAIL: "Author",
+            Column.NAME_EMAIL: "Author",
+            Column.COMMITS: "Commits",
+            Column.ADDED: "Inserted",
+            Column.DELETED: "Removed",
+            Column.EDITS: "Total",
+            Column.PERCENT: "Percent",
+            Column.FIRST_DATE: "First commit",
+            Column.LAST_DATE: "Last commit",
+        }
+
+    @staticmethod
+    def column_to_tex_string_map() -> dict[Column, str]:
+        return {
+            Column.NAME: "\\emph{Author}",
+            Column.EMAIL: "\\emph{Author}",
+            Column.NAME_EMAIL: "\\emph{Author}",
+            Column.COMMITS: "\\emph{Commits}",
+            Column.ADDED: "\\emph{Inserted}",
+            Column.DELETED: "\\emph{Removed}",
+            Column.EDITS: "$\\Sigma\\,\\downarrow$",
+            Column.PERCENT: "\\%",
+            Column.FIRST_DATE: "\\emph{First commit}",
+            Column.LAST_DATE: "\\emph{Last commit}",
+        }
+
+
+class OutputFormat(StrEnum):
+    PLAINTEXT = auto()
+    TEX = auto()
+    TEX_TABLE = auto()
+    CSV = auto()
+    ALIAS = auto()
+
+
+class CollateBy(StrEnum):
+    NAME = auto()
+    EMAIL = auto()
+    BOTH = auto()

--- a/output_formats.py
+++ b/output_formats.py
@@ -1,0 +1,51 @@
+from textwrap import dedent
+from author import Author
+from enums import Column, OutputFormat
+
+
+def output_plaintext(keys: list[Column], authors_list: list[Author], totlines: int):
+    column_names_mapping = Column.column_to_string_map()
+    rows = [[column_names_mapping[c] for c in keys]]
+    lens = [len(r) for r in rows[0]]
+    for author in authors_list:
+        row = author.report(keys, totlines)
+        for i in range(len(lens)):
+            lens[i] = max(lens[i], len(str(row[i])))
+        rows += [row]
+    for row in rows:
+        items = []
+        for i in range(len(lens) - 1):
+            items += [f"{row[i]:<{lens[i] + 2}}"]
+        items += [str(row[-1])]
+        print("".join(items))
+
+
+def output_tex(keys: list[Column], authors_list: list[Author], totlines: int, output_format: OutputFormat):
+    column_names_mapping = Column.column_to_tex_string_map()
+    if output_format == OutputFormat.TEX:
+        print(
+            dedent(
+                """\\documentclass[10pt,border=10pt]{standalone}
+                    \\usepackage{booktabs}
+                    \\usepackage{newtxtext}
+                    \\begin{document}"""
+            )
+        )
+
+    print("\\begin{tabular}{lrrrrr}")
+    print("\\toprule")
+    print(" & ".join([column_names_mapping[c] for c in keys]) + "\\\\")
+    print("\\midrule")
+    for author in authors_list:
+        print((" & ".join([str(x) for x in author.report(keys, totlines)]) + " \\\\"))
+    print("\\bottomrule")
+    print("\\end{tabular}")
+
+    if output_format == OutputFormat.TEX:
+        print("\\end{document}")
+
+
+def output_csv(keys: list[Column], authors_list: list[Author], totlines: int):
+    print(",".join(keys))
+    for author in authors_list:
+        print(",".join([str(x) for x in author.report(keys, totlines)]))


### PR DESCRIPTION
Hello! 

Thanks for the nice project :) 

I wanted to run this on a very large repo 10k+ commits, and it was rather slow. So I decided to add multiprocessing to the code, but got a bit carried away and started polishing the code. 

I hope that I'm not stepping on your toes with by dropping such a big PR onto your project. And sorry for dropping it as a single mega commit. 

The commit consists of:
* Separating out the code into more manageable chunks
* Adding enums to remove most of the "magic strings"
* Adding type hints so that the static type checker can prevent us from shooting ourselves in the foot
* Adding multiprocessing capability

## Multiprocessing performance

Running this command with or without the `--multiprocessing` flag

```bash
time python countlines.py --by name --max-count 1000 --output plaintext /bigrepo
```

With multiprocessing: **0.6** seconds
Without:                 8.4 seconds